### PR TITLE
pagination controls missing when only one page required

### DIFF
--- a/flask_appbuilder/templates/appbuilder/general/lib.html
+++ b/flask_appbuilder/templates/appbuilder/general/lib.html
@@ -59,7 +59,6 @@
 {% macro render_set_page_size(page, page_size, count, modelview_name) %}
 {% if not page %} {% set page = 0 %} {% endif %}
 {% set pages = ((count / page_size)|round(0,'ceil')|int)%}
-{% if pages > 1 %}
 <div class="btn-group">
     <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
     {{_('Page size')}}<span class="caret"></span>
@@ -74,7 +73,6 @@
         {% endfor %}
     </ul>
 </div>
-{% endif %}
 {% endmacro %}
 
 {% macro render_dropdown_orderby(order_columns, label_columns, modelview_name) %}
@@ -110,7 +108,6 @@
 
     {% if not page %} {% set page = 0 %} {% endif %}
     {% set pages = ((count / page_size)|round(0,'ceil')|int)%}
-    {% if pages > 1 %}
     <ul class="pagination pagination-sm" style="display:inherit;">
 
         {% set init_page = 0 %}
@@ -181,7 +178,6 @@
         </li>
     {% endif %}
 </ul>
-{% endif %}
 {% endmacro %}
 
 


### PR DESCRIPTION
Pagination controls is missing when all content fit in one page so it's not possible to revert page size option